### PR TITLE
Async threading modification

### DIFF
--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -488,7 +488,7 @@ class Motor(BaseActor):
         """
         # ensure motor always sends Ack/Nack
         # - Needs to be set before any commands are sent, otherwise
-        #   receiving will timeout and throw an Exception on commands
+        #   receiving will time out and throw an Exception on commands
         #   that do not return a reply
         self._read_and_set_protocol()
 
@@ -527,7 +527,7 @@ class Motor(BaseActor):
 
         if _bits[-3] == "0":
             # motor does not always respond with ack/nack, change
-            # protocol so it does
+            # protocol, so it does
             _bits = list(_bits)
             _bits[-3] = "1"  # sets always ack/nack
             _bits = "".join(_bits)
@@ -746,7 +746,7 @@ class Motor(BaseActor):
     def connect(self):
         """
         Open the ethernet connection to the motor.  The number of
-        reconnection attempts before an exception is ratised is defined
+        reconnection attempts before an exception is raised is defined
         by ``self._setup["max_connection_attempts"]``.
         """
         _allowed_attempts = self._setup["max_connection_attempts"]
@@ -777,7 +777,7 @@ class Motor(BaseActor):
                     self.logger.error(msg)
                     # TODO: make this a custom exception (e.g. MotorConnectionError)
                     #       so other bapsfdaq_motion functionality can respond
-                    #       appropriately...the exception should liekly inherit
+                    #       appropriately...the exception should likely inherit
                     #       from TimeoutError, InterruptedError, ConnectionRefusedError,
                     #       and socket.timeout
                     raise error_
@@ -1158,7 +1158,7 @@ class Motor(BaseActor):
     async def _heartbeat(self):
         """
         :ref:`Coroutine <coroutine>` for the heartbeat monitor of the
-        motor.  The heartbeat will update the motor statuss via
+        motor.  The heartbeat will update the motor status via
         :meth:`retrieve_motor_status` at an interval given by
         :attr:`heartrate`.
 

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -610,6 +610,10 @@ class Motor(BaseActor):
         self._setup["thread"] = value
 
     @property
+    def _thread_id(self):
+        return self._loop._thread_id if self._thread is None else self._thread.ident
+
+    @property
     def heartrate(self) -> NamedTuple:
         """
         Heartrate of the motor monitor, or the time (in sec) between


### PR DESCRIPTION
This PR updates the `Motor.send_command()` so it can...

- Send the command directly to the motor if no event loop is running.

  ```python
  elif not self._loop.is_running():
      # event loop not running, just send commands directly
      return self._send_command(command, *args)
  ```

- If the event loop is running and the command is called from the same thread, then the command is added as a task in the event loop.

  ```python
  elif threading.current_thread().ident == self._thread_id:
      # we are in the same thread as the running event loop, just
      # send the command directly
      tk = self._loop.create_task(self._send_command_async(command, *args))
      self._loop.run_until_complete(tk)
      return tk.result()
  ```

- If the event loop is running and the command is called from a separate thread, then the command is added as a future to the event loop.

  ```python
  # the event loop is running and the command is being sent from
  # outside the event loop thread
  future = asyncio.run_coroutine_threadsafe(
      self._send_command_async(command, *args),
      self._loop
  )
  return future.result(5)
  ```

This is done so we don't run into the situation where a future is waiting on a future, and we're stuck in an infinite loop.

---

Also...

- Fixed a few typos.
- Added a property `_thread_id` to be able to retrieve the thread id of the thread used for the event loop.