### PR TITLE
Create `"zero"` command to set probe zero position

### DIFF
--- a/src/bapsf_motion/actors/axis_.py
+++ b/src/bapsf_motion/actors/axis_.py
@@ -203,7 +203,7 @@ class Axis(BaseActor):
             (
                 u.rev,
                 u.steps,
-                lambda x: x * steps_per_rev,
+                lambda x: int(x * steps_per_rev),
                 lambda x: x / steps_per_rev,
             ),
             (
@@ -216,7 +216,7 @@ class Axis(BaseActor):
                 u.steps,
                 self.units,
                 lambda x: x * units_per_rev / steps_per_rev,
-                lambda x: x * steps_per_rev / units_per_rev,
+                lambda x: int(x * steps_per_rev / units_per_rev),
             ),
         ]
         for equiv in equivs.copy():
@@ -275,6 +275,13 @@ class Axis(BaseActor):
                 args[0] = args[0] * axis_unit.to(
                     motor_unit, equivalencies=self.equivalencies
                 )
+
+                # TODO: There should be a cleaner way of enforcing this
+                #       int conversion...maybe add it to the Motor class,
+                #       but I [Erik] currently feel the conversion should
+                #       happen outside the Motor class
+                if motor_unit is u.steps:
+                    args[0] = int(args[0])
 
         rtn = self.motor.send_command(command, *args)
 

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -241,6 +241,14 @@ class Motor(BaseActor):
             "alarm_reset",
             send="AR"
         ),
+        "current": CommandEntry(
+            "change_current",
+            send="CC",
+            send_processor=lambda value: f"{float(value):.1f}",
+            recv=re.compile(r"CC=(?P<return>[0-9]\.?[0-9]?)"),
+            recv_processor=float,
+            two_way=True,
+        ),
         "deceleration": CommandEntry(
             "deceleration",
             send="DE",
@@ -281,6 +289,14 @@ class Motor(BaseActor):
             recv=re.compile(r"IP=(?P<return>-?[0-9]+)"),
             recv_processor=int,
             units=u.steps,
+        ),
+        "idle_current": CommandEntry(
+            "change_idle_current",
+            send="CI",
+            send_processor=lambda value: f"{float(value):.1f}",
+            recv=re.compile(r"CI=(?P<return>[0-9]\.?[0-9]?)"),
+            recv_processor=float,
+            two_way=True,
         ),
         "move_off_limit": CommandEntry(
             "move_off_limit",

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -480,6 +480,10 @@ class Motor(BaseActor):
                 "speed": 12.5,
                 "accel": 25,
                 "decel": 25,
+                "idle_current": 0.3,  # 30% of current
+                "current": 4.0,  # 4.0 amps
+                "max_idle_current": .9,  # 90% fo current
+                "max_current": 5.0  # 5 amps
             },
             "speed": None,
             "accel": None,

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -294,7 +294,7 @@ class Motor(BaseActor):
             units=u.steps / u.rev,
         ),
         "get_position": CommandEntry(
-            "get_position",
+            "immediate_position",
             send="IP",
             recv=re.compile(r"IP=(?P<return>-?[0-9]+)"),
             recv_processor=int,

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -528,7 +528,7 @@ class Motor(BaseActor):
                 "decel": 25,
                 "idle_current": 0.3,  # 30% of current
                 "current": 4.0,  # 4.0 amps
-                "max_idle_current": .9,  # 90% fo current
+                "max_idle_current": .9,  # 90% of current
                 "max_current": 5.0  # 5 amps
             },
             "speed": None,
@@ -1450,6 +1450,24 @@ class Motor(BaseActor):
         future.result(5)
 
     def set_current(self, percent):
+        r"""
+        Set the peak current setting ("peak of sine") of the stepper
+        drive, also known as the running current.  The value given
+        is a fraction of 0-1 of the peak allowable current defined
+        in  ``_motor["DEFAULTS"]["max_current"]``.
+
+        Setting the running current can affect the idle current, since
+        the max idle current is 90% of the running current.
+
+        Parameters
+        ----------
+        percent: `float`
+            A value of 0 - 1 specifying a fraction of the max running
+            current to set the running current to.  For example,
+            ``0.5`` will set the running current to 50% of the max
+            allowable running current
+            (``_motor["DEFAULTS"]["max_current"]``).
+        """
         if not isinstance(percent, (int, float)):
             self.logger.error(
                 f"Setting motor current, expected a value of 0 - 1 "
@@ -1474,6 +1492,19 @@ class Motor(BaseActor):
         self.send_command("idle_current", new_ic)
 
     def set_idle_current(self, percent):
+        r"""
+        Set the motor's idle current.  The idle current is the current
+        supplied to the stepper motors when the motor is not moving.
+        The value given is a fraction 0 - 0.9 of the running current.
+
+        Parameters
+        ----------
+        percent: `float`
+            A value of 0 - 0.9 specifying a fraction of the running
+            current to set the idle current to.  For example,
+            ``0.5`` will set the idle current to 50% of the running
+            current.
+        """
         max_idle = self._motor["DEFAULTS"]["max_idle_current"]
         if not isinstance(percent, (int, float)):
             self.logger.error(

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -1500,6 +1500,7 @@ class Motor(BaseActor):
         self.send_command("idle_current", new_ic)
 
     def set_position(self, pos):
+        # TODO: command is not properly working up the command chain to Axis and Drive
         if not isinstance(pos, int):
             self.logger.error(
                 f"Setting motor position, expect int between"

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -391,6 +391,12 @@ class Motor(BaseActor):
             two_way=True,
             units=u.steps,
         ),
+        "zero": CommandEntry(
+            "zero",
+            send="",
+            method_command=True,
+            units=u.steps,
+        ),
     }  # type: Dict[str, Optional[Dict[str, Any]]]
 
     #: mapping of motor alarm codes to their descriptive message (specific to STM motors)
@@ -1512,3 +1518,6 @@ class Motor(BaseActor):
 
         self.send_command("current", curr)
         self.send_command("idle_current", ic)
+
+    def zero(self):
+        self.set_position(0)

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -1531,7 +1531,7 @@ class Motor(BaseActor):
         self.send_command("idle_current", new_ic)
 
     def set_position(self, pos):
-        # TODO: command is not properly working up the command chain to Axis and Drive
+
         if not isinstance(pos, int):
             self.logger.error(
                 f"Setting motor position, expect int between"

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -1524,6 +1524,9 @@ class Motor(BaseActor):
         self.send_command("idle_current", new_ic)
 
     def reset_currents(self):
+        """
+        Reset running and idle currents to their default values.
+        """
         curr = self._motor["DEFAULTS"]["current"]
         new_ic = self._motor["DEFAULTS"]["idle_current"] * curr
 
@@ -1531,7 +1534,14 @@ class Motor(BaseActor):
         self.send_command("idle_current", new_ic)
 
     def set_position(self, pos):
+        """
+        Set current motor's absolute position to a value specified by
+        ``pos``.
 
+        pos: `int`
+            An integer in the range of +/- 2,147,483,647 to set the
+            motor's absolute position.
+        """
         if not isinstance(pos, int):
             self.logger.error(
                 f"Setting motor position, expect int between"
@@ -1552,4 +1562,5 @@ class Motor(BaseActor):
         self.send_command("idle_current", ic)
 
     def zero(self):
+        """Define current motor position as zero."""
         self.set_position(0)


### PR DESCRIPTION
This PR incorporates commands that allow the user to set the absolute position of a motor.  To do so, the following was added:

- Enforce that the `Axis` class always delivers position values to `Motor` as an integer.  This is because motor position is defined in steps, which is an integer.
- add default current settings to `_motor["DEFAULTS"]` dictionary
- created the commands
  - **`current`**:  for setting and requesting the motor running current (in units of amps)
  - **`encoder_position`**:  for setting and requesting the encoder motor position
  - **`idle_current`**:  for setting and requesting the motor idle current (in units of amps)
  - **`reset_currents`**:  reset motor running and idle currents to their default values
  - **`set_current`**:  set motor running current as a fraction of the max allowable running current, the max allowable running current is defined in the defaults dictionary
  - **`idle_idl_current`**:  set motor idle current as a fraction of the current running current
  - **`set_position`**:  set the absolute motor position.  This sets the position for the encoder and the internal motor counter
  - **`set_position_SP`**:  set or request the motor absolute position as defined in the motor's internal counter (separate from encoder position)...`set_position` should be used instead to ensure the internal counter and encoder stay synced
  - **`zero`**:  set the current motor position to zero (convenient zeroing version of `set_position`)
- Add appropriate docstrings to all newly created method commands