### PR TITLE
Create & Implement `EventActor` base class

### DIFF
--- a/src/bapsf_motion/actors/__init__.py
+++ b/src/bapsf_motion/actors/__init__.py
@@ -1,9 +1,17 @@
 __all__ = []
-__actors__ = ["Axis", "BaseActor", "Drive", "Manager", "MotionGroup", "Motor"]
+__actors__ = [
+    "Axis",
+    "BaseActor",
+    "Drive",
+    "EventActor",
+    "Manager",
+    "MotionGroup",
+    "Motor",
+]
 __all__ += __actors__
 
 from bapsf_motion.actors.axis_ import Axis
-from bapsf_motion.actors.base import BaseActor
+from bapsf_motion.actors.base import BaseActor, EventActor
 from bapsf_motion.actors.drive_ import Drive
 from bapsf_motion.actors.manager_ import Manager
 from bapsf_motion.actors.motion_group_ import MotionGroup

--- a/src/bapsf_motion/actors/axis_.py
+++ b/src/bapsf_motion/actors/axis_.py
@@ -10,12 +10,12 @@ import logging
 
 from typing import Any, Dict
 
-from bapsf_motion.actors.base import BaseActor
+from bapsf_motion.actors.base import EventActor
 from bapsf_motion.actors.motor_ import Motor
 from bapsf_motion.utils import units as u
 
 
-class Axis(BaseActor):
+class Axis(EventActor):
     """
     The `Axis` actor is the next level actor above the |Motor| actor.
     This actor is ignorant of how it is situated in a probe drive, but
@@ -83,55 +83,48 @@ class Axis(BaseActor):
         loop: asyncio.AbstractEventLoop = None,
         auto_run: bool = False,
     ):
-        super().__init__(logger=logger, name=name)
+        # TODO: update units so inches can be used
+        self._motor = None
+        self._units = u.Unit(units)
+        self._units_per_rev = units_per_rev * self._units / u.rev
 
-        self._init_instance_attrs()
-        self.motor = Motor(
-            ip=ip,
-            name="motor",
-            logger=self.logger,
+        super().__init__(
+            name=name,
+            logger=logger,
             loop=loop,
             auto_run=False,
         )
 
-        # TODO: update units so inches can be used
-        self._units = u.Unit(units)
-        self._units_per_rev = units_per_rev * self._units / u.rev
+        self._motor = Motor(
+            ip=ip,
+            name="motor",
+            logger=self.logger,
+            loop=self.loop,
+            auto_run=False,
+        )
 
-        if auto_run:
-            self.run()
+        self.run(auto_run=auto_run)
 
-    def _init_instance_attrs(self):
-        """Initialize the class instance attributes."""
-        self.motor = None
-        self._units = None
-        self._units_per_rev = None
+    def _configure_before_run(self):
+        return
 
-    def run(self):
+    def _initialize_tasks(self):
+        return
+
+    def run(self, auto_run=True):
         """
         Activate the `asyncio` `event loop`_.   If the event loop is
         running, then nothing happens.  Otherwise, the event loop is
         placed in a separate thread and set to
         `~asyncio.loop.run_forever`.
         """
-        self.motor.run()
+        if self.motor is not None:
+            self.motor.run(auto_run=auto_run)
+        super().run(auto_run=auto_run)
 
-    def stop_running(self, delay_loop_stop=False):
-        r"""
-        Stop the actor's `event loop`_\ .  All actor tasks will be
-        cancelled, the connection to the motor will be shutdown, and
-        the event loop will be stopped.
-
-        Parameters
-        ----------
-        delay_loop_stop: bool
-            If `True`, then do NOT stop the `event loop`_\ .  In this
-            case it is assumed the calling functionality is managing
-            additional tasks in the event loop, and it is up to that
-            functionality to stop the loop.  (DEFAULT: `False`)
-
-        """
-        self.motor.stop_running(delay_loop_stop=delay_loop_stop)
+    def terminate(self, delay_loop_stop=False):
+        self.motor.terminate(delay_loop_stop=True)
+        super().terminate(delay_loop_stop=delay_loop_stop)
 
     @property
     def config(self) -> Dict[str, Any]:
@@ -142,7 +135,11 @@ class Axis(BaseActor):
             "units": str(self.units),
             "units_per_rev": self.units_per_rev.value.item()
         }
-    config.__doc__ = BaseActor.config.__doc__
+    config.__doc__ = EventActor.config.__doc__
+
+    @property
+    def motor(self) -> Motor:
+        return self._motor
 
     @property
     def is_moving(self) -> bool:

--- a/src/bapsf_motion/actors/axis_.py
+++ b/src/bapsf_motion/actors/axis_.py
@@ -111,11 +111,6 @@ class Axis(EventActor):
     def _initialize_tasks(self):
         return
 
-    def run(self, auto_run=True):
-        if self.motor is not None:
-            self.motor.run(auto_run=auto_run)
-        super().run(auto_run=auto_run)
-
     def terminate(self, delay_loop_stop=False):
         self.motor.terminate(delay_loop_stop=True)
         super().terminate(delay_loop_stop=delay_loop_stop)

--- a/src/bapsf_motion/actors/axis_.py
+++ b/src/bapsf_motion/actors/axis_.py
@@ -128,6 +128,7 @@ class Axis(EventActor):
 
     @property
     def motor(self) -> Motor:
+        """Instance of the |Motor| object that belongs to |Axis|."""
         return self._motor
 
     @property

--- a/src/bapsf_motion/actors/axis_.py
+++ b/src/bapsf_motion/actors/axis_.py
@@ -112,12 +112,6 @@ class Axis(EventActor):
         return
 
     def run(self, auto_run=True):
-        """
-        Activate the `asyncio` `event loop`_.   If the event loop is
-        running, then nothing happens.  Otherwise, the event loop is
-        placed in a separate thread and set to
-        `~asyncio.loop.run_forever`.
-        """
         if self.motor is not None:
             self.motor.run(auto_run=auto_run)
         super().run(auto_run=auto_run)

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -5,10 +5,12 @@ Module for functionality focused around the [Abstract] base actors.
 __all__ = ["BaseActor"]
 __actors__ = ["BaseActor"]
 
+import asyncio
 import logging
+import threading
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Union
 
 
 # TODO: create an EventActor for an actor that utilizes asyncio event loops
@@ -99,3 +101,148 @@ class BaseActor(ABC):
 #       - will likely need abstract methods _actor_setup_pre_loop() and
 #         _actor_setup_post_loop() for setup actions before and after
 #         the loop creation, respectively.
+
+
+class EventActor(BaseActor, ABC):
+    def __init__(
+        self,
+        *,
+        name: str = None,
+        logger: logging.Logger = None,
+        loop: asyncio.AbstractEventLoop = None,
+        auto_run: bool = False,
+    ):
+
+        super().__init__(name=name, logger=logger)
+
+        self._thread = None
+        self._loop = self.setup_event_loop(loop)
+        self._tasks = None
+
+        self._configure_before_run()
+        self._initialize_tasks()
+
+        self.run(auto_run)
+
+    @property
+    def tasks(self) -> List[asyncio.Task]:
+        r"""
+        List of `asyncio.Task`\ s this actor has in its `event loop`_.
+        """
+        if self._tasks is None:
+            self._tasks = []
+
+        return self._tasks
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        """The `asyncio` :term:`event loop` for the actor."""
+        return self._loop
+
+    @property
+    def thread(self) -> threading.Thread:
+        """The `~threading.Thread` the `event loop`_ is running in."""
+        return self._thread
+
+    @property
+    def _thread_id(self) -> Union[int, None]:
+        """Unique ID for the thread the loop is running in."""
+        if self.loop is None or not self.loop.is_running():
+            # no loop has been created or loop is not running
+            return None
+
+        # get ident from running loop
+
+        # return self.loop._thread_id if self._thread is None else self.thread.ident
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._thread_id_async(),
+            self._loop
+        )
+        return future.result(5)
+
+    async def _thread_id_async(self):
+        return threading.current_thread().ident
+
+    @abstractmethod
+    def _configure_before_run(self):
+        ...
+
+    @abstractmethod
+    def _initialize_tasks(self):
+        ...
+
+    def setup_event_loop(self, loop: Optional[asyncio.AbstractEventLoop]):
+        """
+        Set up the `asyncio` `event loop`_.  If the given loop is not an
+        instance of `~asyncio.AbstractEventLoop`, then a new loop will
+        be created.
+
+        Parameters
+        ----------
+        loop: `asyncio.AbstractEventLoop`
+            `asyncio` `event loop`_ for the actor's tasks
+
+        """
+        # 1. loop is given and running
+        #    - store loop
+        # 2. loop is given and not running
+        #    - store loop
+        # 3. loop is NOT given
+        #    - create new loop
+        #    - store loop
+        # get a valid event loop
+        if loop is None:
+            loop = asyncio.new_event_loop()
+        elif not isinstance(loop, asyncio.AbstractEventLoop):
+            self.logger.warning(
+                "Given asyncio event is not valid.  Creating a new event loop to use."
+            )
+            loop = asyncio.new_event_loop()
+        return loop
+
+    def run(self, auto_run=True):
+        """
+        Activate the `asyncio` `event loop`_.   If the event loop is
+        running, then nothing happens.  Otherwise, the event loop is
+        placed in a separate thread and set to
+        `~asyncio.loop.run_forever`.
+        """
+        if self._loop.is_running():
+            return
+        elif not auto_run:
+            return
+
+        _thread = threading.Thread(target=self._loop.run_forever)
+        _thread.start()
+        self._thread = _thread
+
+    def terminate(self, delay_loop_stop=False):
+        r"""
+        Stop the actor's `event loop`_\ .  All actor tasks will be
+        cancelled, the connection to the motor will be shutdown, and
+        the event loop will be stopped.
+
+        Parameters
+        ----------
+        delay_loop_stop: bool
+            If `True`, then do NOT stop the `event loop`_\ .  In this
+            case it is assumed the calling functionality is managing
+            additional tasks in the event loop, and it is up to that
+            functionality to stop the loop.  (DEFAULT: `False`)
+
+        """
+        # TODO: add additional motor shutdown tasks (i.e. stop and disable)
+        for task in list(self.tasks):
+            task.cancel()
+            self.tasks.remove(task)
+
+        # try:
+        #     self.socket.close()
+        # except AttributeError:
+        #     pass
+
+        if delay_loop_stop:
+            return
+
+        self._loop.call_soon_threadsafe(self._loop.stop)

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -152,12 +152,24 @@ class EventActor(BaseActor, ABC):
 
     @property
     def thread(self) -> threading.Thread:
-        """The `~threading.Thread` the `event loop`_ is running in."""
+        """
+        The `~threading.Thread` the `event loop`_ is running in.
+
+        If :attr:`loop` was given during instantiation, then there is
+        no way of obtaining the thread object the event loop is
+        running in.  In this case :attr:`thread` will be `None`.
+
+        The thread id can always be retrieved using :attr:`_thread_id`.
+        """
         return self._thread
 
     @property
     def _thread_id(self) -> Union[int, None]:
-        """Unique ID for the thread the loop is running in."""
+        """
+        Unique ID for the thread the loop is running in.
+
+        `None` if the :attr:`loop` does not exit or is not running.
+        """
         if self.loop is None or not self.loop.is_running():
             # no loop has been created or loop is not running
             return None

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -157,7 +157,7 @@ class EventActor(BaseActor, ABC):
 
         future = asyncio.run_coroutine_threadsafe(
             self._thread_id_async(),
-            self._loop
+            self.loop
         )
         return future.result(5)
 
@@ -245,4 +245,4 @@ class EventActor(BaseActor, ABC):
         if delay_loop_stop:
             return
 
-        self._loop.call_soon_threadsafe(self._loop.stop)
+        self.loop.call_soon_threadsafe(self.loop.stop)

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -155,6 +155,7 @@ class EventActor(BaseActor, ABC):
 
         # return self.loop._thread_id if self._thread is None else self.thread.ident
 
+        # get thread id from inside the event loop
         future = asyncio.run_coroutine_threadsafe(
             self._thread_id_async(),
             self.loop

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -208,14 +208,11 @@ class EventActor(BaseActor, ABC):
         placed in a separate thread and set to
         `~asyncio.loop.run_forever`.
         """
-        if self._loop.is_running():
-            return
-        elif not auto_run:
+        if self.loop is None or self.loop.is_running() or not auto_run:
             return
 
-        _thread = threading.Thread(target=self._loop.run_forever)
-        _thread.start()
-        self._thread = _thread
+        self._thread = threading.Thread(target=self._loop.run_forever)
+        self._thread.start()
 
     def terminate(self, delay_loop_stop=False):
         r"""

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -232,15 +232,9 @@ class EventActor(BaseActor, ABC):
             functionality to stop the loop.  (DEFAULT: `False`)
 
         """
-        # TODO: add additional motor shutdown tasks (i.e. stop and disable)
         for task in list(self.tasks):
             task.cancel()
             self.tasks.remove(task)
-
-        # try:
-        #     self.socket.close()
-        # except AttributeError:
-        #     pass
 
         if delay_loop_stop:
             return

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -224,6 +224,13 @@ class EventActor(BaseActor, ABC):
         running, then nothing happens.  Otherwise, the event loop is
         placed in a separate thread and set to
         `~asyncio.loop.run_forever`.
+
+        Parameters
+        ----------
+        auto_run: `bool`, optional
+            If `False`, then do NOT start the event loop.  This keyword
+            is only made available to help with subclassing.
+            (DEFAULT: `True`)
         """
         if self.loop is None or self.loop.is_running() or not auto_run:
             return

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -2,8 +2,8 @@
 Module for functionality focused around the [Abstract] base actors.
 """
 
-__all__ = ["BaseActor"]
-__actors__ = ["BaseActor"]
+__all__ = ["BaseActor", "EventActor"]
+__actors__ = ["BaseActor", "EventActor"]
 
 import asyncio
 import logging

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -173,7 +173,9 @@ class EventActor(BaseActor, ABC):
     def _initialize_tasks(self):
         ...
 
-    def setup_event_loop(self, loop: Optional[asyncio.AbstractEventLoop]):
+    def setup_event_loop(
+        self, loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
         """
         Set up the `asyncio` `event loop`_.  If the given loop is not an
         instance of `~asyncio.AbstractEventLoop`, then a new loop will

--- a/src/bapsf_motion/actors/base.py
+++ b/src/bapsf_motion/actors/base.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional, Union
 
 class BaseActor(ABC):
     """
-    Base class for any Actor class.
+    Low-level base class for any Actor class.
 
     Parameters
     ----------
@@ -28,18 +28,6 @@ class BaseActor(ABC):
     logger : `~logging.Logger`, optional
         The instance of `~logging.Logger` that the Actor should record
         events and status updates.
-
-    Examples
-    --------
-
-    >>> ba = BaseActor(name="BoIt")
-    >>> ba.name
-    'DoIt'
-    >>> ba.logger
-    <Logger Actor.DoIt (WARNING)>
-    >>> ba.logger.warning("This is a warning")
-    This is a warning
-
     """
 
     def __init__(

--- a/src/bapsf_motion/actors/motion_group_.py
+++ b/src/bapsf_motion/actors/motion_group_.py
@@ -14,7 +14,7 @@ from collections import UserDict
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-from bapsf_motion.actors.base import BaseActor
+from bapsf_motion.actors.base import EventActor
 from bapsf_motion.actors.drive_ import Drive
 from bapsf_motion.motion_builder import MotionBuilder
 from bapsf_motion import transform
@@ -540,7 +540,7 @@ class MotionGroupConfig(UserDict):
         self._transform = tr
 
 
-class MotionGroup(BaseActor):
+class MotionGroup(EventActor):
     r"""
     The `MotionGroup` actor brings together all the components that
     are needed to move a probe drive around the motion space.  These
@@ -595,9 +595,14 @@ class MotionGroup(BaseActor):
 
         config = MotionGroupConfig(config)
 
-        super().__init__(logger=logger, name=config["name"])
+        super().__init__(
+            name=config["name"],
+            logger=logger,
+            loop=loop,
+            auto_run=False,
+        )
 
-        self._drive = self._spawn_drive(config["drive"], loop)
+        self._drive = self._spawn_drive(config["drive"])
 
         self._mb = self._setup_motion_builder(config["motion_builder"])
         self._ml_index = None
@@ -609,11 +614,16 @@ class MotionGroup(BaseActor):
         self._config.link_motion_builder(self.mb)
         self._config.link_transform(self.transform)
 
-        if auto_run:
-            self.run()
+        self.run(auto_run=auto_run)
+
+    def _configure_before_run(self):
+        return
+
+    def _initialize_tasks(self):
+        return
 
     def _spawn_drive(
-        self, config: Dict[str, Any], loop: asyncio.AbstractEventLoop
+        self, config: Dict[str, Any]
     ) -> Drive:
         """
         Spawn and return the |Drive| instance for the motion group.
@@ -622,18 +632,14 @@ class MotionGroup(BaseActor):
         ----------
         config: `dict`
             Drive component of the motion group configuration.
-
-        loop:
-            Event loop for the |Drive| class to send motor commands
-            through.
         """
 
         dr = Drive(
-            logger=self.logger,
-            loop=loop,
-            auto_run=False,
-            name=config["name"],
             axes=list(config["axes"].values()),
+            name=config["name"],
+            logger=self.logger,
+            loop=self.loop,
+            auto_run=False,
         )
         return dr
 
@@ -667,40 +673,14 @@ class MotionGroup(BaseActor):
         tr_type = tr_config.pop("type")
         return transform.transform_factory(self.drive, tr_type=tr_type, **config)
 
-    def run(self):
-        """
-        Activate the `asyncio` `event loop`_ used by :attr:`drive`.  If
-        the event loop is running, then nothing happens.  Otherwise,
-        the event loop is placed in a separate thread and set to
-        `~asyncio.loop.run_forever`.
-        """
-        if self.drive is not None:
-            self.drive.run()
-
-    def stop_running(self, delay_loop_stop=False):
-        r"""
-        Stop the actor's `event loop`_\ .  All actor tasks will be
-        cancelled, the connection to the motor will be shutdown, and
-        the event loop will be stopped.
-
-        Parameters
-        ----------
-        delay_loop_stop: bool
-            If `True`, then do NOT stop the `event loop`_\ .  In this
-            case it is assumed the calling functionality is managing
-            additional tasks in the event loop, and it is up to that
-            functionality to stop the loop.  (DEFAULT: `False`)
-
-        """
-        if self.drive is None:
-            return
-
-        self.drive.stop_running(delay_loop_stop=delay_loop_stop)
+    def terminate(self, delay_loop_stop=False):
+        self.drive.terminate(delay_loop_stop=True)
+        super().terminate(delay_loop_stop=delay_loop_stop)
 
     @property
     def config(self):
         return self._config
-    config.__doc__ = BaseActor.config.__doc__
+    config.__doc__ = EventActor.config.__doc__
 
     @property
     def drive(self) -> Drive:

--- a/src/bapsf_motion/actors/motion_group_.py
+++ b/src/bapsf_motion/actors/motion_group_.py
@@ -599,7 +599,7 @@ class MotionGroup(BaseActor):
 
         self._drive = self._spawn_drive(config["drive"], loop)
 
-        self._ml = self._setup_motion_builder(config["motion_builder"])
+        self._mb = self._setup_motion_builder(config["motion_builder"])
         self._ml_index = None
 
         self._transform = self._setup_transform(config["transform"])
@@ -710,7 +710,7 @@ class MotionGroup(BaseActor):
     @property
     def mb(self) -> MotionBuilder:
         """Instance of |MotionBuilder| associated with the motion group."""
-        return self._ml
+        return self._mb
 
     @property
     def ml_index(self):

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -16,7 +16,7 @@ import time
 from collections import namedtuple, UserDict
 from typing import Any, AnyStr, Callable, Dict, List, NamedTuple, Optional, Union
 
-from bapsf_motion.actors.base import BaseActor
+from bapsf_motion.actors.base import EventActor
 from bapsf_motion.utils import ipv4_pattern, SimpleSignal
 from bapsf_motion.utils import units as u
 
@@ -162,7 +162,7 @@ class CommandEntry(UserDict):
         return self._command
 
 
-class Motor(BaseActor):
+class Motor(EventActor):
     """
     An actor class for directly communicating to an ethernet based
     stepper motor.  This actor is only aware of the motor, and is
@@ -478,33 +478,27 @@ class Motor(BaseActor):
         loop: asyncio.AbstractEventLoop = None,
         auto_run: bool = False,
     ):
-        self._init_instance_variables()
-
-        super().__init__(name=name, logger=logger)
 
         self.ip = ip
-        self.connect()
+        self._setup = self._setup_defaults.copy()
+        self._motor = self._motor_defaults.copy()
+        self._status = self._status_defaults.copy()
 
-        # loop needs to be setup before any commands are sent to the motor
-        self.setup_event_loop(loop)
+        # simple signal to tell handlers that _status changed
+        self.status_changed = SimpleSignal()
+        self.movement_started = SimpleSignal()
+        self.movement_finished = SimpleSignal()
 
-        # configure motor before any other method sends motor commands
-        self._configure_motor()
+        super().__init__(
+            name=name,
+            logger=logger,
+            loop=loop,
+            auto_run=auto_run,
+        )
 
-        self._get_motor_parameters()
-        self.send_command("retrieve_motor_status")
-
-        if auto_run:
-            self.run()
-
-    def _init_instance_variables(self):
-        """
-        Initialized object instance variables, which define operating
-        parameters for the actor.
-        """
-        # : parameters that define the setup of the Motor class (actual motor settings
-        # should be defined in _motor)
-        self._setup = {
+    @property
+    def _setup_defaults(self) -> Dict[str, Any]:
+        return {
             "name": "",
             "logger": None,
             "loop": None,
@@ -516,10 +510,25 @@ class Motor(BaseActor):
                 base=2.0, active=0.2
             ),  # in seconds
             "port": 7776,  # 7776 is Applied Motion's TCP port, 7775 is the UDP port
-        }  # type: Dict[str, Any]
+        }
 
-        #: these are setting that determine the motor parameters
-        self._motor = {
+    @property
+    def setup(self):
+        _setup = {
+            **self._setup,
+            "name": self.name,
+            "logger": self.logger,
+            "loop": self.loop,
+            "thread": self.thread,
+            "tasks": self.tasks,
+            "socket": self.socket,
+        }
+        self._setup = _setup
+        return self._setup
+
+    @property
+    def _motor_defaults(self) -> Dict[str, Any]:
+        return {
             "ip": None,
             "manufacturer": "Applied Motion Products",
             "model": "STM23S-3EE",
@@ -538,10 +547,15 @@ class Motor(BaseActor):
             "accel": None,
             "decel": None,
             "protocol_settings": None,
-        }  # type: Dict[str, Any]
+        }
 
-        #: these are parameters that define the current state of the motor
-        self._status = {
+    @property
+    def motor(self):
+        return self._motor
+
+    @property
+    def _status_defaults(self) -> Dict[str, Any]:
+        return {
             "connected": False,
             "position": None,
             "alarm": None,
@@ -558,12 +572,13 @@ class Motor(BaseActor):
                 "CW": False,
                 "CCW": False,
             },
-        }  # type: Dict[str, Any]
+        }
 
-        #: simple signal to tell handlers that _status changed
-        self.status_changed = SimpleSignal()
-        self.movement_started = SimpleSignal()
-        self.movement_finished = SimpleSignal()
+    @property
+    def status(self) -> Dict[str, Any]:
+        """Current status of the motor."""
+        # TODO: dictionary keys and explanations to the docstring
+        return self._status
 
     def _configure_motor(self):
         """
@@ -660,15 +675,6 @@ class Motor(BaseActor):
         )
 
     @property
-    def name(self):
-        """Given motor name."""
-        return self._setup["name"]
-
-    @name.setter
-    def name(self, value):
-        self._setup["name"] = value
-
-    @property
     def ip(self) -> str:
         """IPv4 address for the motor"""
         return self._motor["ip"]
@@ -688,42 +694,7 @@ class Motor(BaseActor):
             "name": self.name,
             "ip": self.ip,
         }
-    config.__doc__ = BaseActor.config.__doc__
-
-    @property
-    def logger(self) -> logging.Logger:
-        """The `~logger.Logger` being used for the actor."""
-        return self._setup["logger"]
-
-    @logger.setter
-    def logger(self, value):
-        self._setup["logger"] = value
-
-    @property
-    def _loop(self) -> asyncio.events.AbstractEventLoop:
-        """`asyncio` `event loop`_ being used for motor communication."""
-        return self._setup["loop"]
-
-    @_loop.setter
-    def _loop(self, value):
-        self._setup["loop"] = value
-
-    @property
-    def _thread(self) -> threading.Thread:
-        """The `~threading.Thread` the `event loop`_ is running in."""
-        return self._setup["thread"]
-
-    @_thread.setter
-    def _thread(self, value):
-        self._setup["thread"] = value
-
-    @property
-    def _thread_id(self) -> Union[int, None]:
-        """Unique ID for the thread the loop is running in."""
-        if self._loop is None and self._thread is None:
-            return None
-
-        return self._loop._thread_id if self._thread is None else self._thread.ident
+    config.__doc__ = EventActor.config.__doc__
 
     @property
     def heartrate(self) -> NamedTuple:
@@ -734,12 +705,6 @@ class Motor(BaseActor):
         (2) ``heartrate.active`` for when the motor is moving.
         """
         return self._setup["heartrate"]
-
-    @property
-    def status(self) -> Dict[str, Any]:
-        """Current status of the motor."""
-        # TODO: dictionary keys and explanations to the docstring
-        return self._status
 
     @property
     def steps_per_rev(self) -> u.steps/u.rev:
@@ -764,16 +729,6 @@ class Motor(BaseActor):
         self._setup["socket"] = value
 
     @property
-    def tasks(self) -> List[asyncio.Task]:
-        """
-        List of `asyncio.Task`\ s this actor has in the `event loop`_.
-        """
-        if self._setup["tasks"] is None:
-            self._setup["tasks"] = []
-
-        return self._setup["tasks"]
-
-    @property
     def is_moving(self) -> bool:
         """`True` if the motor is actively moving, `False` otherwise."""
         is_moving = self.status["moving"]
@@ -791,6 +746,19 @@ class Motor(BaseActor):
         self._update_status(position=pos)
         return pos
 
+    def _configure_before_run(self):
+        # actions to be done during object instantiation, but before
+        # the asyncio event loop starts running.
+
+        self.connect()
+        self._configure_motor()
+        self._get_motor_parameters()
+        self.send_command("retrieve_motor_status")
+
+    def _initialize_tasks(self):
+        tk = self.loop.create_task(self._heartbeat())
+        self.tasks.append(tk)
+
     def _update_status(self, **values):
         """
         Update ``self._status` dictionary with the given arguments ``**values``.
@@ -807,43 +775,6 @@ class Motor(BaseActor):
             self.status_changed.emit(True)
 
         self._status = new_status
-
-    def setup_event_loop(self, loop: Optional[asyncio.AbstractEventLoop]):
-        """
-        Set up the `asyncio` `event loop`_.  If the given loop is not an
-        instance of `~asyncio.AbstractEventLoop`, then a new loop will
-        be created.  The `event loop`_ is, then populated with the
-        relevant actor tasks (e.g. ``self._heartbeat()``).
-
-        Parameters
-        ----------
-        loop: `asyncio.AbstractEventLoop`
-            `asyncio` `event loop`_ for the actor's tasks
-
-        """
-        # 1. loop is given and running
-        #    - store loop
-        #    - add tasks
-        # 2. loop is given and not running
-        #    - store loop
-        #    - add tasks
-        # 3. loop is NOT given
-        #    - create new loop
-        #    - store loop
-        #    - add tasks
-        # get a valid event loop
-        if loop is None:
-            loop = asyncio.new_event_loop()
-        elif not isinstance(loop, asyncio.AbstractEventLoop):
-            self.logger.warning(
-                "Given asyncio event is not valid.  Creating a new event loop to use."
-            )
-            loop = asyncio.new_event_loop()
-        self._loop = loop
-
-        # populate loop with tasks
-        task = self._loop.create_task(self._heartbeat())
-        self.tasks.append(task)
 
     def connect(self):
         """
@@ -887,7 +818,7 @@ class Motor(BaseActor):
                     #       and socket.timeout
                     raise error_
 
-        if self._loop is not None:
+        if self.loop is not None:
             self._get_motor_parameters()
             self._configure_motor()
 
@@ -924,22 +855,22 @@ class Motor(BaseActor):
             meth = getattr(self, command)
             return meth(*args)
 
-        elif not self._loop.is_running():
+        elif not self.loop.is_running():
             # event loop not running, just send commands directly
             return self._send_command(command, *args)
 
         elif threading.current_thread().ident == self._thread_id:
             # we are in the same thread as the running event loop, just
             # send the command directly
-            tk = self._loop.create_task(self._send_command_async(command, *args))
-            self._loop.run_until_complete(tk)
+            tk = self.loop.create_task(self._send_command_async(command, *args))
+            self.loop.run_until_complete(tk)
             return tk.result()
 
         # the event loop is running and the command is being sent from
         # outside the event loop thread
         future = asyncio.run_coroutine_threadsafe(
             self._send_command_async(command, *args),
-            self._loop
+            self.loop
         )
         return future.result(5)
 
@@ -1310,38 +1241,10 @@ class Motor(BaseActor):
             old_HR = heartrate
             await asyncio.sleep(heartrate)
 
-    def run(self):
-        """
-        Activate the `asyncio` `event loop`_.   If the event loop is
-        running, then nothing happens.  Otherwise, the event loop is
-        placed in a separate thread and set to
-        `~asyncio.loop.run_forever`.
-        """
-        if self._loop.is_running():
-            return
+    def terminate(self, delay_loop_stop=False):
+        super().terminate(delay_loop_stop=True)
 
-        self._thread = threading.Thread(target=self._loop.run_forever)
-        self._thread.start()
-
-    def stop_running(self, delay_loop_stop=False):
-        r"""
-        Stop the actor's `event loop`_\ .  All actor tasks will be
-        cancelled, the connection to the motor will be shutdown, and
-        the event loop will be stopped.
-
-        Parameters
-        ----------
-        delay_loop_stop: bool
-            If `True`, then do NOT stop the `event loop`_\ .  In this
-            case it is assumed the calling functionality is managing
-            additional tasks in the event loop, and it is up to that
-            functionality to stop the loop.  (DEFAULT: `False`)
-
-        """
         # TODO: add additional motor shutdown tasks (i.e. stop and disable)
-        for task in list(self.tasks):
-            task.cancel()
-            self.tasks.remove(task)
 
         try:
             self.socket.close()
@@ -1351,7 +1254,10 @@ class Motor(BaseActor):
         if delay_loop_stop:
             return
 
-        self._loop.call_soon_threadsafe(self._loop.stop)
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+    def stop_running(self, delay_loop_stop=False):
+        self.terminate(delay_loop_stop=delay_loop_stop)
 
     def stop(self):
         """Stop motor movement."""
@@ -1451,15 +1357,15 @@ class Motor(BaseActor):
         delay: ~numbers.Real
             Number of seconds to sleep.
         """
-        if not self._loop.is_running():
+        if not self.loop.is_running():
             time.sleep(delay)
         elif threading.current_thread().ident == self._thread_id:
-            tk = self._loop.create_task(self._sleep_async(delay))
-            self._loop.run_until_complete(tk)
+            tk = self.loop.create_task(self._sleep_async(delay))
+            self.loop.run_until_complete(tk)
 
         future = asyncio.run_coroutine_threadsafe(
             self._sleep_async(delay),
-            self._loop
+            self.loop
         )
         future.result(5)
 

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -479,7 +479,6 @@ class Motor(EventActor):
         auto_run: bool = False,
     ):
 
-        self.ip = ip
         self._setup = self._setup_defaults.copy()
         self._motor = self._motor_defaults.copy()
         self._status = self._status_defaults.copy()
@@ -488,6 +487,8 @@ class Motor(EventActor):
         self.status_changed = SimpleSignal()
         self.movement_started = SimpleSignal()
         self.movement_finished = SimpleSignal()
+
+        self.ip = ip
 
         super().__init__(
             name=name,

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -173,18 +173,22 @@ class Motor(EventActor):
     ----------
     ip: `str`
         IPv4 address for the motor
+
     name: `str`, optional
         Name the motor.  If `None`, then the name will be automatically
         generated. (DEFAULT: `None`)
+
     logger: `~logging.Logger`, optional
         An instance of `~logging.Logger` that the Actor will record
         events and status updates to.  If `None`, then a logger will
         automatically be generated. (DEFUALT: `None`)
+
     loop: `asyncio.AbstractEventLoop`, optional
         Instance of an `asyncio` `event loop`_. Communication with the
         motor will happen primaritly through the evenet loop.  If
         `None`, then an `event loop`_ will be auto-generated.
         (DEFAULT: `None`)
+
     auto_run: bool, optional
         If `True`, then the `event loop`_ will be placed in a separate
         thread and started.  This is all done via the :meth:`run`

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -499,6 +499,7 @@ class Motor(EventActor):
 
     @property
     def _setup_defaults(self) -> Dict[str, Any]:
+        """Default values for :attr:`setup`."""
         return {
             "name": "",
             "logger": None,
@@ -515,6 +516,9 @@ class Motor(EventActor):
 
     @property
     def setup(self):
+        """
+        Dictionary of class setup parameters.
+        """
         _setup = {
             **self._setup,
             "name": self.name,
@@ -529,6 +533,7 @@ class Motor(EventActor):
 
     @property
     def _motor_defaults(self) -> Dict[str, Any]:
+        """Default values for :attr:`motor`."""
         return {
             "ip": None,
             "manufacturer": "Applied Motion Products",
@@ -551,11 +556,16 @@ class Motor(EventActor):
         }
 
     @property
-    def motor(self):
+    def motor(self) -> Dict[str, Any]:
+        """
+        Dictionary containing properties of the Applied Motion STM
+        motor.
+        """
         return self._motor
 
     @property
     def _status_defaults(self) -> Dict[str, Any]:
+        """Default values for :attr:`status`."""
         return {
             "connected": False,
             "position": None,

--- a/src/bapsf_motion/actors/motor_.py
+++ b/src/bapsf_motion/actors/motor_.py
@@ -205,7 +205,7 @@ class Motor(EventActor):
     ...     auto_run=True,
     ... )
     >>> # now stop the actor, which stops the event loop
-    >>> m1.stop_running()
+    >>> m1.terminate()
 
     Using `Motor` with ``auto_start=False``.
 
@@ -220,7 +220,7 @@ class Motor(EventActor):
     >>> # start the actor, with starts the event loop
     >>> m1.run()
     >>> # now stop the actor, which stops the event loop
-    >>> m1.stop_running()
+    >>> m1.terminate()
     """
     #: available commands that can be sent to the motor
     _commands = {
@@ -1256,9 +1256,6 @@ class Motor(EventActor):
             return
 
         self.loop.call_soon_threadsafe(self.loop.stop)
-
-    def stop_running(self, delay_loop_stop=False):
-        self.terminate(delay_loop_stop=delay_loop_stop)
 
     def stop(self):
         """Stop motor movement."""


### PR DESCRIPTION
The PR creates the `EventActor` abstract base class with inherits from the `BaseActor` abstract base class, and is designed to contain functionality that setups up the `asyncio` event loop, run the event loop, and terminate the event loop.

### `EventActor` creates the following properties:

- `tasks`: A list of `asyncio` tasks that will run in the event loop.
- `loop`: The `asyncio` event loop.
- `thread`: The thread the `asyncio` is placed in, or `None`.  If an event loop is passed in during instantiation, then the class has no way of obtaining the thread object the event loop belongs too.
- `_thread_id`: The unique id for the thread that the loop exists in.  This can and is determined by running the coroutine `_thread_id_async` in the event loop.

### `EventActor` creates the following methods:

- `_thread_id_async`: `asyncio` coroutine that can be executed in the event loop to get the event loop's thread id using `threading.current_thread().ident`.
- _`_configure_before_run`_: abstract method that gets executed by `__init__` before the event loop is activated.  This can be used to do any additional setup by the subclass before the event loop is activated.
- _`_initialize_tasks`_: abstract method that gets executed by `__init__` after `_configure_before_run` but before the event loop is activated.  This is used to setup all the `asyncio` tasks that will be executed in the event loop once the loop is activated.
- `setup_event_loop`: method for setting up the event loop, but does not run the event loop.
- `run`: activate the event loop
- `terminate`: close/end any active tasks in the event loop and stop the event loop

---

The `EventActor` was integrated into the `Motor`, `Axis`, `Drive`, and `MotionGroup` classes.